### PR TITLE
code formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ Spark Submit
 You can also create an assembly jar with all of the dependencies for running either the java or scala
 versions of the code and run the job with the spark-submit script
 
-./sbt/sbt assembly OR mvn package
-cd $SPARK_HOME; ./bin/spark-submit   --class com.oreilly.learningsparkexamples.[lang].[example] ../learning-spark-examples/target/scala-2.10/learning-spark-examples-assembly-0.0.1.jar
+`./sbt/sbt assembly` OR `mvn package`
+
+`cd $SPARK_HOME; ./bin/spark-submit   --class com.oreilly.learningsparkexamples.[lang].[example] ../learning-spark-examples/target/scala-2.10/learning-spark-examples-assembly-0.0.1.jar`
 
 [![Learning Spark](http://akamaicovers.oreilly.com/images/0636920028512/cat.gif)](http://www.jdoqocy.com/click-7645222-11260198?url=http%3A%2F%2Fshop.oreilly.com%2Fproduct%2F0636920028512.do%3Fcmp%3Daf-strata-books-videos-product_cj_9781449358600_%2525zp&cjsku=0636920028512)


### PR DESCRIPTION
The examples for building the assembly were hard to read because markdown doesn't understand single newline. Fixed 'em.
